### PR TITLE
Do not send expired requests and retry up to 3 times

### DIFF
--- a/lib/puppet/functions/adminapi/adminapi.rb
+++ b/lib/puppet/functions/adminapi/adminapi.rb
@@ -1,7 +1,7 @@
 #
 # Functions required for querying Serveradmin
 #
-# Copyright (c) 2019 InnoGames GmbH
+# Copyright (c) 2020 InnoGames GmbH
 #
 
 require 'net/http'
@@ -9,37 +9,57 @@ require 'uri'
 require 'digest'
 require 'json'
 require 'openssl'
+require 'timeout'
 
 require 'puppet/util/errors'
 
 module Adminapi
     def self.request(endpoint, payload)
         application_id = Digest::SHA1.hexdigest(ENV['SERVERADMIN_TOKEN'])
-        timestamp = Time.now.getutc.to_i.to_s
         payload_json = JSON.generate(payload)
         uri = URI(ENV['SERVERADMIN_BASE_URL'] + endpoint)
 
         req = Net::HTTP::Get.new(uri.request_uri)
         req['Content-Encoding'] = 'application/x-json'
-        req['X-Timestamp'] = timestamp
         req['X-Application'] = application_id
-        req['X-SecurityToken'] = OpenSSL::HMAC.hexdigest(
-            OpenSSL::Digest.new('sha1'),
-            ENV['SERVERADMIN_TOKEN'],
-            timestamp + ':' + payload_json,
-        )
         req.body = payload_json
 
-        res = Net::HTTP.start(uri.host, uri.port, :use_ssl => uri.scheme == 'https') do |http|
-            http.request(req)
+        # Ruby 2.x has max_retries implemented, lets change to it once we
+        # updated.
+        #
+        # The Serveradmin backend discards requests which are more than 16
+        # seconds in the past or future to avoid timing attacks. We must
+        # therefore set the timeout accordingly and make sure we sign the
+        # requests with a new timestamp before retrying.
+        max_retries = 3
+        until max_retries <= 0 do
+            begin
+                res = Net::HTTP.start(uri.host, uri.port, :use_ssl => uri.scheme == 'https', :open_timeout => 15, :read_timeout => 60) do |http|
+                    timestamp = Time.now.getutc.to_i.to_s
+                    req['X-Timestamp'] = timestamp
+                    req['X-SecurityToken'] = OpenSSL::HMAC.hexdigest(
+                        OpenSSL::Digest.new('sha1'),
+                        ENV['SERVERADMIN_TOKEN'],
+                        timestamp + ':' + payload_json)
+
+                    http.request(req)
+                end
+            rescue Timeout::TimeoutError
+                warning('Request to Serveradmin timed out on opening connection or while connected, retrying!')
+                sleep 5
+                max_retries -= 1
+            else
+                break
+            end
         end
 
-        raise(Puppet::ParseError, "Serveradmin retuned " + res.code) unless res.code[0] == '2'
+        raise(Puppet::ParseError, "Can't establish connection to Serveradmin") unless max_retries > -1
+        raise(Puppet::ParseError, "Serveradmin returned " + res.code) unless res.code[0] == '2'
 
         res_json = JSON.parse(res.body)
 
-        raise(Puppet::ParseError, "Serveradmin retuned no status") unless res_json['status']
-        raise(Puppet::ParseError, "Serveradmin retuned status " + res_json['status']) unless res_json['status'] == 'success'
+        raise(Puppet::ParseError, "Serveradmin returned no status") unless res_json['status']
+        raise(Puppet::ParseError, "Serveradmin returned status " + res_json['status']) unless res_json['status'] == 'success'
 
         return res_json['result']
     end


### PR DESCRIPTION
Requests are dismissed by the Serveradmin API backend if older/younger than 16 seconds to avoid race conditions.

- Set timeout to establish connection to 15 seconds
- Retry sending request up to 3 times if it fails