### PR TITLE
Rescue Timeout::Error

### DIFF
--- a/lib/puppet/functions/adminapi/adminapi.rb
+++ b/lib/puppet/functions/adminapi/adminapi.rb
@@ -44,7 +44,7 @@ module Adminapi
 
                     http.request(req)
                 end
-            rescue Timeout::TimeoutError
+            rescue Timeout::Error
                 warning('Request to Serveradmin timed out on opening connection or while connected, retrying!')
                 sleep 5
                 max_retries -= 1


### PR DESCRIPTION
The correct class for this case is Timeout::Error.

This fixes the error of when the connection to Serveradmin fails.

```
[puppetserver] Puppet Puppet::Parser::Compiler failed with error
NameError: uninitialized constant Timeout::TimeoutError on node xxx
```