### PR TITLE
Add optional no_fail switch to commit

### DIFF
--- a/lib/puppet/functions/adminapi/adminapi.rb
+++ b/lib/puppet/functions/adminapi/adminapi.rb
@@ -14,7 +14,7 @@ require 'timeout'
 require 'puppet/util/errors'
 
 module Adminapi
-    def self.request(endpoint, payload)
+    def self.request(endpoint, payload, no_fail = false)
         application_id = Digest::SHA1.hexdigest(ENV['SERVERADMIN_TOKEN'])
         payload_json = JSON.generate(payload)
         uri = URI(ENV['SERVERADMIN_BASE_URL'] + endpoint)
@@ -32,15 +32,17 @@ module Adminapi
         # therefore set the timeout accordingly and make sure we sign the
         # requests with a new timestamp before retrying.
         max_retries = 3
-        until max_retries <= 0 do
+        until max_retries <= 0
             begin
-                res = Net::HTTP.start(uri.host, uri.port, :use_ssl => uri.scheme == 'https', :open_timeout => 15, :read_timeout => 60) do |http|
+                res = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', open_timeout: 15,
+                                                          read_timeout: 60) do |http|
                     timestamp = Time.now.getutc.to_i.to_s
                     req['X-Timestamp'] = timestamp
                     req['X-SecurityToken'] = OpenSSL::HMAC.hexdigest(
                         OpenSSL::Digest.new('sha1'),
                         ENV['SERVERADMIN_TOKEN'],
-                        timestamp + ':' + payload_json)
+                        timestamp + ':' + payload_json
+                    )
 
                     http.request(req)
                 end
@@ -53,30 +55,49 @@ module Adminapi
             end
         end
 
-        raise(Puppet::ParseError, "Can't establish connection to Serveradmin") unless max_retries > -1
-        raise(Puppet::ParseError, "Serveradmin returned " + res.code + " > " + res.body ) unless res.code[0] == '2'
+        unless max_retries > -1
+            return nil if no_fail
+
+            raise(Puppet::ParseError, "Can't establish connection to Serveradmin")
+        end
+
+        unless res.code[0] == '2'
+            return nil if no_fail
+
+            raise(Puppet::ParseError, 'Serveradmin returned ' + res.code + ' > ' + res.body)
+        end
 
         res_json = JSON.parse(res.body)
 
-        raise(Puppet::ParseError, "Serveradmin returned no status") unless res_json['status']
-        raise(Puppet::ParseError, "Serveradmin returned status " + res_json['status'] + " > " + res.body) unless res_json['status'] == 'success'
+        unless res_json['status']
+            return nil if no_fail
 
-        return res_json['result']
+            raise(Puppet::ParseError, 'Serveradmin returned no status')
+        end
+
+        unless res_json['status'] == 'success'
+            return nil if no_fail
+
+            raise(Puppet::ParseError,
+                  'Serveradmin returned status ' + res_json['status'] + ' > ' + res.body)
+        end
+
+        res_json['result']
     end
 
-    def self.query(filters, restrict, order_by)
+    def self.query(filters, restrict, order_by, no_fail = false)
         request('/dataset/query', {
-            'filters'  => filters,
-            'restrict' => restrict,
-            'order_by' => order_by,
-        })
+                    'filters' => filters,
+                    'restrict' => restrict,
+                    'order_by' => order_by
+                }, no_fail)
     end
 
-    def self.commit(created, changed, deleted)
+    def self.commit(created, changed, deleted, no_fail = false)
         request('/dataset/commit', {
-            'created' => created,
-            'changed' => changed,
-            'deleted' => deleted,
-        })
+                    'created' => created,
+                    'changed' => changed,
+                    'deleted' => deleted
+                }, no_fail)
     end
 end

--- a/lib/puppet/functions/adminapi/change_multi_attribute.rb
+++ b/lib/puppet/functions/adminapi/change_multi_attribute.rb
@@ -15,10 +15,11 @@ Puppet::Functions.create_function(:'adminapi::change_multi_attribute') do
         param 'Adminapi::Attribute_id', :attribute
         param 'Array[Adminapi::Attribute_value]', :additions
         param 'Array[Adminapi::Attribute_value]', :removals
+        optional_param 'Boolean', :no_fail
         return_type 'Undef'
     end
 
-    def execute(object_id, attribute, additions, removals)
+    def execute(object_id, attribute, additions, removals, no_fail = false)
         if additions.none? and removals.none?
             return nil
         end
@@ -30,6 +31,6 @@ Puppet::Functions.create_function(:'adminapi::change_multi_attribute') do
                 'add'    => additions,
                 'remove' => removals,
             },
-        }], [])
+        }], [], no_fail)
     end
 end


### PR DESCRIPTION
Adds no_fail optional param to skip most of the failures, intended to be used "best effort" commit attempts, which are (for now) only triggered by `change_multi_attribute` function

Also includes rubocop formatter fixes on `adminapi.rb`